### PR TITLE
S machine n makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ TEST_FILES := $(notdir $(TEST_SRCS))
 TEST_OBJS := $(TEST_FILES:.ml=.cmx)
 TEST_OBJS := $(addprefix $(BUILD_DIR)/, $(TEST_OBJS))
 
-all: $(BUILD_DIR) $(BUILD_DIR)/$(NAME)
+all: $(BUILD_DIR) $(NAME)
 
 test: $(BUILD_DIR) $(BUILD_DIR)/types.cmx $(BUILD_DIR)/parser.cmx $(BUILD_DIR)/transition.cmx $(BUILD_DIR)/compute.cmx $(TEST_OBJS) 
 	@echo "Building and running tests..."
@@ -32,7 +32,7 @@ $(BUILD_DIR)/%.cmx: tests/%.ml
 	@echo "Compiling test $<..."
 	ocamlfind ocamlopt -package $(PKGS) -linkpkg -I $(BUILD_DIR) -c $< -o $@
 
-$(BUILD_DIR)/$(NAME): $(OBJS)
+$(NAME): $(OBJS)
 	@echo "Linking $@..."
 	ocamlfind ocamlopt -package $(PKGS) -linkpkg -I $(BUILD_DIR) -o $@ $(OBJS)
 

--- a/machines/balanced_binary.json
+++ b/machines/balanced_binary.json
@@ -2,7 +2,7 @@
   "name": "balanced_binary",
   "alphabet": ["1", ".", "0", "y", "n"],
   "blank": ".",
-  "states": ["scanright", "scanleft", "check_1", "check_0", "validate_1", "validate_0", "HALT"],
+  "states": ["scanright", "scanleft", "check_1", "check_0", "validate_1", "validate_0", "write_no", "HALT"],
   "initial": "scanright",
   "finals": ["HALT"],
   "transitions": {
@@ -28,12 +28,17 @@
     ],
     "validate_1": [
       {"read": "1", "to_state": "scanleft", "write": ".", "action": "LEFT"},
-      {"read": "0", "to_state": "HALT", "write": "n", "action": "LEFT"},
-      {"read": ".", "to_state": "HALT", "write": "y", "action": "RIGHT"}
+      {"read": "0", "to_state": "write_no", "write": "0", "action": "RIGHT"},
+      {"read": ".", "to_state": "write_no", "write": ".", "action": "RIGHT"}
     ],
     "validate_0": [
-      {"read": "0", "to_state": "scanleft", "write": ".", "action": "LEFT"},
-      {"read": "1", "to_state": "HALT", "write": "y", "action": "RIGHT"},
+      {"read": "0", "to_state": "write_no", "write": "0", "action": "RIGHT"},
+      {"read": "1", "to_state": "write_no", "write": "1", "action": "RIGHT"}, 
+      {"read": ".", "to_state": "HALT", "write": "n", "action": "RIGHT"}
+    ],
+    "write_no": [
+      {"read": "1", "to_state": "write_no", "write": "1", "action": "RIGHT"},
+      {"read": "0", "to_state": "write_no", "write": "0", "action": "RIGHT"},
       {"read": ".", "to_state": "HALT", "write": "n", "action": "RIGHT"}
     ]
   }

--- a/machines/balanced_binary.json
+++ b/machines/balanced_binary.json
@@ -7,7 +7,7 @@
   "finals": ["HALT"],
   "transitions": {
     "scanright": [
-      {"read": "1", "to_state": "check_0", "write": ".", "action": "RIGHT"},
+      {"read": "1", "to_state": "check_0", "write": "1", "action": "RIGHT"},
       {"read": "0", "to_state": "check_1", "write": ".", "action": "RIGHT"},
       {"read": ".", "to_state": "HALT", "write": "y", "action": "RIGHT"}
     ],

--- a/tests/test_machines.ml
+++ b/tests/test_machines.ml
@@ -141,16 +141,15 @@ let test_run_machine_palindrome () =
     run_machine_test "machines/palindrome.json" "0" "y"
   )
 
-
-let test_run_machine_is_even () =
+let test_run_machine_balanced_binary () =
   let yellow = "\027[33m" in
   let reset = "\027[0m" in
   let filename = "machines/balanced_binary.json" in
 
   print_endline (yellow ^ "\nRunning tests for balanced_binary machine" ^ reset);
  (* Valid cases (should output 'y') *)
- test "Test 1 (Valid: 1)" (fun () ->
-  run_machine_test filename "1" "y"
+ test "Test 1 (Invalid: 1)" (fun () ->
+  run_machine_test filename "1" "n"
   );
   test "Test 2 (Valid: 01)" (fun () ->
     run_machine_test filename "01" "y"
@@ -167,7 +166,7 @@ let test_run_machine_is_even () =
 
   (* Invalid cases (should output 'n') *)
   test "Test 6 (Invalid: 11)" (fun () ->
-    run_machine_test filename "11" "n"
+    run_machine_test filename "11" "1n"
   );
   test "Test 7 (Invalid: 00011)" (fun () ->
     run_machine_test filename "00011" "n"
@@ -176,26 +175,31 @@ let test_run_machine_is_even () =
     run_machine_test filename "0001111" "n"
   );
   test "Test 9 (Invalid: 10)" (fun () ->
-    run_machine_test filename "10" "n"
+    run_machine_test filename "10" "0n"
   );
   test "Test 10 (Invalid: 0)" (fun () ->
     run_machine_test filename "0" "n"
   );
-  test "Test 11 (Invalid: empty input)" (fun () ->
-    run_machine_test filename "" "n"
+
+  test "Test 11 (Invalid: 111)" (fun () ->
+    run_machine_test filename "111" "11n"
+  );
+
+  test "Test 12b (Invalid: 1111111)" (fun () ->
+    run_machine_test filename "1111111" "111111n"
   );
 
   test "Test 12 (Invalid: 000010111)" (fun () ->
-    run_machine_test filename "000010111" "n"
+    run_machine_test filename "000010111" "10n"
   );
 
   test "Test 13 (Invalid: 000011111)" (fun () ->
     run_machine_test filename "000011111" "n"
-  )  
+  )
 
 let () =
     test_run_machine_unary_sub (); 
     (* test_run machine_unary_add ();   *)
     test_run_machine_palindrome();
-    test_run_machine_is_even();
+    test_run_machine_balanced_binary();
     run_tests ()

--- a/tests/test_machines.ml
+++ b/tests/test_machines.ml
@@ -149,7 +149,7 @@ let test_run_machine_balanced_binary () =
   print_endline (yellow ^ "\nRunning tests for balanced_binary machine" ^ reset);
  (* Valid cases (should output 'y') *)
  test "Test 1 (Invalid: 1)" (fun () ->
-  run_machine_test filename "1" "n"
+  run_machine_test filename "1" "1n"
   );
   test "Test 2 (Valid: 01)" (fun () ->
     run_machine_test filename "01" "y"
@@ -166,27 +166,27 @@ let test_run_machine_balanced_binary () =
 
   (* Invalid cases (should output 'n') *)
   test "Test 6 (Invalid: 11)" (fun () ->
-    run_machine_test filename "11" "1n"
+    run_machine_test filename "11" "11n"
   );
   test "Test 7 (Invalid: 00011)" (fun () ->
     run_machine_test filename "00011" "n"
   );
   test "Test 8 (Invalid: 0001111)" (fun () ->
-    run_machine_test filename "0001111" "n"
+    run_machine_test filename "0001111" "1n"
   );
   test "Test 9 (Invalid: 10)" (fun () ->
-    run_machine_test filename "10" "0n"
+    run_machine_test filename "10" "10n"
   );
   test "Test 10 (Invalid: 0)" (fun () ->
     run_machine_test filename "0" "n"
   );
 
   test "Test 11 (Invalid: 111)" (fun () ->
-    run_machine_test filename "111" "11n"
+    run_machine_test filename "111" "111n"
   );
 
   test "Test 12b (Invalid: 1111111)" (fun () ->
-    run_machine_test filename "1111111" "111111n"
+    run_machine_test filename "1111111" "1111111n"
   );
 
   test "Test 12 (Invalid: 000010111)" (fun () ->
@@ -194,7 +194,7 @@ let test_run_machine_balanced_binary () =
   );
 
   test "Test 13 (Invalid: 000011111)" (fun () ->
-    run_machine_test filename "000011111" "n"
+    run_machine_test filename "000011111" "1n"
   )
 
 let () =


### PR DESCRIPTION
Main changes to balanced binary machine
- validate_0 signals an error mode already, because you're not supposed to have zeroes at the end.
- scanright reading 1 means error too, so I don't erase it to keep input (because why not)
- write_no state that replaces halting, and moves to a blank to drop no and halt, instead of overwriting a character

Also makefile fix